### PR TITLE
Rename RTFM to RTIC for the rfc repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -28,6 +28,6 @@ In the Rust community we strive to go the extra step to look out for each other.
 
 And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could've communicated better — remember that it's your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
 
-The enforcement policies listed above apply to all official venues; including the official Matrix room (#rtfm-rs:matrix.org); GitHub repositories under rtfm-rs; and all forums under rtfm-rs.
+The enforcement policies listed above apply to all official venues; including the official Matrix room (#rtic-rs:matrix.org); GitHub repositories under rtic-rs; and all forums under rtic-rs.
 
 *Adapted from the [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling) as well as the [Contributor Covenant v1.3.0](https://www.contributor-covenant.org/version/1/3/0/).*

--- a/README.md
+++ b/README.md
@@ -1,46 +1,52 @@
-# Real Time For the Masses
+# Real-Time Interrupt-driven Concurrency
 
-> Coordination repository of the development of the Real Time For the Masses framework
+> Coordination repository of the development of the
+  Real-Time Interrupt-driven Concurrency framework
 
-This repository [issue tracker] is used by the developers to coordinate efforts towards making Rust
-a great choice for embedded real-time development.
+This repository [issue tracker] is used by the developers to coordinate efforts
+towards making RTIC a great choice for embedded real-time development.
 
-[issue tracker]: https://github.com/rtfm-rs/rfcs/issues
+[issue tracker]: https://github.com/rtic-rs/rfcs/issues
 
-**Want to get started with real-time embedded development with Rust?** Check out our
-[RTFM book][book].
+**Want to get started with real-time embedded development with Rust?**
+
+Check out the [Rust-embedded book][book] and the [RTIC book][rtic]
 
 [book]: https://docs.rust-embedded.org/book
+[rtic]: https://rtic.rs
 
-### The developers
+## The developers
 
-- [@japaric]
-- [@korken89]
-- [@perlindgren]
-- [@nils-grepit]
-- [@texitoi]
+- [@japaric](https://github.com/japaric)
+- [@korken89](https://github.com/korken89)
+- [@perlindgren](https://github.com/perlindgren)
+- [@nils-grepit](https://github.com/nils-grepit)
+- [@texitoi](https://github.com/texitoi)
 
 ### Hibernating
 
-The following members have put themselves into hibernation the hibernation state, due to being absent or busy for an extended amount of time. See [ops/hibernating.md](https://github.com/rtfm-rs/rfcs/blob/master/ops/hibernating.md).
+The following members have put themselves into hibernation the hibernation state,
+due to being absent or busy for an extended amount of time.
+See [ops/hibernating.md](https://github.com/rtic-rs/rfcs/blob/master/ops/hibernating.md).
 
 ### Contact
 
 - To come into contact with us please open an issue here
-- Or come and talk to us in the [RTFM Matrix Room]
+- Or come and talk to us in the [RTIC Matrix Room]
 
-[RTFM Matrix Room]: https://matrix.to/#/!yafYEipFNsXDdwiHMT:matrix.org
+[RTIC Matrix Room]: https://matrix.to/#/!yafYEipFNsXDdwiHMT:matrix.org
 
 ## RFCs
 
-When the team deems it necessary the RFC process may be used to make decisions or to design
-processes, user interfaces, APIs, etc.
+When the team deems it necessary the RFC process may be used to make decisions
+or to design processes, user interfaces, APIs, etc.
 
 Learn more about the Rust's RFC process (which is the same as our own) [here][rust-rfc].
 
 [rust-rfc]: https://rust-lang.github.io/rfcs/
 
 To create an RFC, simply:
+
 - clone this repo to your own personal one
 - copy `0000-template.md` to `text/0000-my-feature.md` (where "my-feature" is
   descriptive. Don't assign an RFC number yet)

--- a/minutes/2019-10-09.md
+++ b/minutes/2019-10-09.md
@@ -1,4 +1,4 @@
-# RTFM meeting
+# RTIC meeting
 
 2019-10-09
 
@@ -6,16 +6,16 @@
 
 - v0.5 release
   - see action items
-- RFC: lock optimization - https://github.com/rtfm-rs/rfcs/issues/19
+- RFC: lock optimization - https://github.com/rtic-rs/rfcs/issues/19
   - to be evaluated as an opt-in Cargo feature
-- RFC: goodbye Exclusive - https://github.com/rtfm-rs/rfcs/issues/17
+- RFC: goodbye Exclusive - https://github.com/rtic-rs/rfcs/issues/17
    - to be evaluated as 2 competing 0.6 RFCs: 'lock required everywhere' vs 'auto-wrap in Exclusive'
 - v0.4.x release
 - next meeting the 2019-10-16, 20.00 CET?
 
 ## Action items
 
-- [ ] @japaric: will update copyright notices and Cargo metadata of all crates under the rtfm-rs org
+- [ ] @japaric: will update copyright notices and Cargo metadata of all crates under the rtic-rs org
 - [ ] @japaric: postpone the rename RFC
 - [ ] @japaric: pre-release v0.5.0-beta after the two previous items are completed
 - [ ] @per: make a PR for opt-in lock optimization

--- a/ops/hibernating.md
+++ b/ops/hibernating.md
@@ -4,10 +4,10 @@ A member that will be absent or busy for an extended period of time and not able
 to participate in the Team during that time should put themselves in "hibernation"
 state. During this hibernation period:
 
-- The member will be removed from their GitHub teams'. `cc @rtfm-rs/$team`
+- The member will be removed from their GitHub teams'. `cc @rtic-rs/$team`
   will *not* cc them.
 
-- The member name will be removed from the list of teams in the rtfm-rs/rfcs
+- The member name will be removed from the list of teams in the rtic-rs/rfcs
   README, but they will be listed under the 'Hibernating' section of that
   README.
 
@@ -17,5 +17,5 @@ state. During this hibernation period:
 
 To enter or leave the hibernation state the member will:
 
-- Notify their teams (e.g. `cc @rtfm-rs/$team`) and send a PR to
-  rtfm-rs/rfcs updating the README to reflect their hibernation state.
+- Notify their teams (e.g. `cc @rtic-rs/$team`) and send a PR to
+  rtic-rs/rfcs updating the README to reflect their hibernation state.

--- a/ops/matrix.md
+++ b/ops/matrix.md
@@ -1,9 +1,9 @@
 # Matrix Operational Notes
 
-The RTFM developers use the following Matrix room for our regular
+The RTIC developers use the following Matrix room for our regular
 meetings and community discussion:
 
-[#rtfm-rs:matrix.org](https://matrix.to/#/!yafYEipFNsXDdwiHMT:matrix.org)
+[#rtic-rs:matrix.org](https://matrix.to/#/!yafYEipFNsXDdwiHMT:matrix.org)
 
 The document details the organization of the room.
 
@@ -12,7 +12,7 @@ The document details the organization of the room.
 See the [Matrix Moderation Guide](https://matrix.org/docs/guides/moderation)
 for information on how Matrix administration and permissions work.
 
-RTFM [core team](https://github.com/orgs/rtfm-rs/teams/devs) members are
+RTIC [core team](https://github.com/orgs/rtic-rs/teams/devs) members are
 channel administrators (PL100), responsible for both maintaining the channel as
 required and enforcing the Team's Code of Conduct.
 
@@ -42,7 +42,7 @@ the team's Code of Conduct.
 
 For a team member to request to become a channel moderator (or a new core team
 member to become an administrator), they should contact a core team member
-[via GitHub](https://github.com/orgs/rtfm-rs/teams/devs) with their
+[via GitHub](https://github.com/orgs/rtic-rs/teams/devs) with their
 Matrix username (e.g., `@username:matrix.org`) to be given moderator
 permissions.
 

--- a/ops/msrv.md
+++ b/ops/msrv.md
@@ -1,6 +1,6 @@
 # Minimum Supported Rust Version (MSRV)
 
-This text documents the MSRV policy used in the crates maintained by the RTFM developers.
+This text documents the MSRV policy used in the crates maintained by the RTIC developers.
 
 - Changing the MSRV of a crate is a breaking change and requires a semver bump:
   minor version bump if the crate is pre-1.0 and a major version bump if the

--- a/ops/post-transfer.md
+++ b/ops/post-transfer.md
@@ -2,7 +2,7 @@
 
 ## Travis CI
 
-Browse to https://travis-ci.org/rtfm-rs/repo-name/settings and make sure that "Build pushed
+Browse to https://travis-ci.org/rtic-rs/repo-name/settings and make sure that "Build pushed
 pull requests" is enabled.
 
 
@@ -13,7 +13,7 @@ Push a commit to `master` that does the following:
 - Creates `.github/CODEOWNERS` with the following contents:
 
 ``` text
-* rtfm-rs/team-name collaborator-name another-collaborator
+* rtic-rs/team-name collaborator-name another-collaborator
 ```
 
 - Adds a copy of `CODE_OF_CONDUCT.md`. Don't forget to adjust the team name and associated
@@ -56,7 +56,7 @@ matrix:
 
 <!-- TODO add this -->
 
-This project is developed and maintained by the [RTFM team][team].
+This project is developed and maintained by the [RTIC team][team].
 
 <!-- ... omitting stuff in between ... -->
 
@@ -65,11 +65,11 @@ This project is developed and maintained by the [RTFM team][team].
 ## Code of Conduct
 
 Contribution to this crate is organized under the terms of the [Rust Code of
-Conduct][CoC], the maintainer of this crate, the [RTFM team][team], promises
+Conduct][CoC], the maintainer of this crate, the [RTIC team][team], promises
 to intervene to uphold that code of conduct.
 
 [CoC]: CODE_OF_CONDUCT.md
-[team]: https://github.com/orgs/rtfm-rs/teams/devs
+[team]: https://github.com/orgs/rtic-rs/teams/devs
 ```
 
 - If the repository uses CI, configure bors. Add a `.github/bors.toml` file with these contents:
@@ -85,7 +85,7 @@ status = ["continuous-integration/travis-ci/push"]
 
 If the repository uses CI, update bors settings.
 
-- Browse to https://app.bors.tech/repositories, click on rtfm-rs/repo-name and then switch
+- Browse to https://app.bors.tech/repositories, click on rtic-rs/repo-name and then switch
   to the "Settings" tab.
 
 - Synchronize both "Reviewers" and "Members" to people with "Push" (write) access to the
@@ -95,7 +95,7 @@ If the repository uses CI, update bors settings.
 
 Update the repository settings.
 
-- Browse to https://github.com/rtfm-rs/repo-name/settings and switch to the "Collaborators &
+- Browse to https://github.com/rtic-rs/repo-name/settings and switch to the "Collaborators &
   teams" tab.
 
 - Add the team that will oversee the project and give them "Admin" permissions.
@@ -121,5 +121,5 @@ If applicable, add new owners to crates.io. Have the current owner add the team 
 the crate as a team owner.
 
 ```
-$ cargo owner --add github:rtfm-rs:team-name
+$ cargo owner --add github:rtic-rs:team-name
 ```

--- a/ops/publish.md
+++ b/ops/publish.md
@@ -35,13 +35,13 @@ Open a PR that:
 <!-- ... omitting stuff in between ... -->
 
 <!-- TODO Change the start of the range -->
-[Unreleased]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.3...HEAD
 
 <!-- TODO Add this new link -->
-[v0.5.3]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.5.2...v0.5.3
+[v0.5.3]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.2...v0.5.3
 
 <!-- NOTE This was already here -->
-[v0.5.2]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.5.1...v0.5.2
+[v0.5.2]: https://github.com/rtic-rs/cortex-m-rtic/compare/v0.5.1...v0.5.2
 ```
 
 - Bumps the crate version in `Cargo.toml`.

--- a/ops/review.md
+++ b/ops/review.md
@@ -21,4 +21,4 @@ need to be approved by the whole team (see [voting majority]) before they are se
 
 - At this point you can review the PR and send it to bors.
 
-[voting majority]: https://github.com/rtfm-rs/rfcs/blob/master/ops/0136-teams.md#voting-majority
+[voting majority]: https://github.com/rtic-rs/rfcs/blob/master/ops/0136-teams.md#voting-majority


### PR DESCRIPTION
The README among other things was not updated to reflect the name change.